### PR TITLE
the issue at AsyncExpandableListView.java

### DIFF
--- a/asyncexpandablelist/src/main/java/com/ericliu/asyncexpandablelist/async/AsyncExpandableListView.java
+++ b/asyncexpandablelist/src/main/java/com/ericliu/asyncexpandablelist/async/AsyncExpandableListView.java
@@ -114,12 +114,12 @@ public class AsyncExpandableListView<T1, T2> extends CollectionView<T1, T2> {
         }
 
         expandedGroupOrdinal = groupOrdinal;
-        mCallbacks.onStartLoadingGroup(groupOrdinal);
         for (OnGroupStateChangeListener onGroupStateChangeListener : mOnGroupStateChangeListeners.keySet()) {
             if (mOnGroupStateChangeListeners.get(onGroupStateChangeListener) == groupOrdinal) {
                 onGroupStateChangeListener.onGroupStartExpending();
             }
         }
+        mCallbacks.onStartLoadingGroup(groupOrdinal);
     }
 
 


### PR DESCRIPTION
make onGroupStartExpending() before onStartLoadingGroup(), the animation will be normal if AsyncTask or Handler not use in onStartLoadingGroup().